### PR TITLE
Add ECDSA and RSA signing/verification

### DIFF
--- a/src/gleam/crypto.gleam
+++ b/src/gleam/crypto.gleam
@@ -195,3 +195,11 @@ pub fn verify_signed_message(
     False -> Error(Nil)
   }
 }
+
+/// Key encoding formats for import and export.
+pub type KeyFormat {
+  /// PEM format - Base64 encoded with header/footer lines.
+  Pem
+  /// DER format - Raw binary ASN.1 encoding.
+  Der
+}

--- a/src/gleam/crypto/ecdsa.gleam
+++ b/src/gleam/crypto/ecdsa.gleam
@@ -1,0 +1,131 @@
+//// ECDSA cryptographic operations for signing and verification.
+
+import gleam/crypto.{type HashAlgorithm, type KeyFormat}
+
+/// ECDSA private key for signing operations.
+pub type PrivateKey
+
+/// ECDSA public key for verification operations.
+pub type PublicKey
+
+/// ECDSA elliptic curves.
+pub type Curve {
+  /// NIST P-256 curve (also known as secp256r1 or prime256v1).
+  P256
+  /// NIST P-384 curve (also known as secp384r1).
+  P384
+  /// NIST P-521 curve (also known as secp521r1).
+  P521
+}
+
+/// Generate a new ECDSA key pair for the specified curve.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let assert Ok(#(private_key, public_key)) = ecdsa.generate_key_pair(curve: ecdsa.P256)
+/// ```
+///
+@external(erlang, "gleam_crypto_ecdsa_ffi", "generate_key_pair")
+@external(javascript, "../../gleam_crypto_ecdsa_ffi.mjs", "generateKeyPair")
+pub fn generate_key_pair(
+  curve curve: Curve,
+) -> Result(#(PrivateKey, PublicKey), Nil)
+
+/// Import an ECDSA private key from PEM or DER encoded data.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let assert Ok(key) = ecdsa.private_key(pem_data, format: crypto.Pem)
+/// ```
+///
+@external(erlang, "gleam_crypto_ecdsa_ffi", "private_key")
+@external(javascript, "../../gleam_crypto_ecdsa_ffi.mjs", "privateKey")
+pub fn private_key(
+  data: BitArray,
+  format format: KeyFormat,
+) -> Result(PrivateKey, Nil)
+
+/// Import an ECDSA public key from PEM or DER encoded data.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let assert Ok(key) = ecdsa.public_key(pem_data, format: crypto.Pem)
+/// ```
+///
+@external(erlang, "gleam_crypto_ecdsa_ffi", "public_key")
+@external(javascript, "../../gleam_crypto_ecdsa_ffi.mjs", "publicKey")
+pub fn public_key(
+  data: BitArray,
+  format format: KeyFormat,
+) -> Result(PublicKey, Nil)
+
+/// Export an ECDSA private key to PEM or DER format.
+///
+@external(erlang, "gleam_crypto_ecdsa_ffi", "private_key_to_bytes")
+@external(javascript, "../../gleam_crypto_ecdsa_ffi.mjs", "privateKeyToBytes")
+pub fn private_key_to_bytes(
+  key key: PrivateKey,
+  format format: KeyFormat,
+) -> BitArray
+
+/// Export an ECDSA public key to PEM or DER format.
+///
+@external(erlang, "gleam_crypto_ecdsa_ffi", "public_key_to_bytes")
+@external(javascript, "../../gleam_crypto_ecdsa_ffi.mjs", "publicKeyToBytes")
+pub fn public_key_to_bytes(
+  key key: PublicKey,
+  format format: KeyFormat,
+) -> BitArray
+
+/// Extract the public key from an ECDSA private key.
+///
+@external(erlang, "gleam_crypto_ecdsa_ffi", "public_key_from_private")
+@external(javascript, "../../gleam_crypto_ecdsa_ffi.mjs", "publicKeyFromPrivate")
+pub fn public_key_from_private(key key: PrivateKey) -> PublicKey
+
+/// Sign a message using an ECDSA private key.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let signature = ecdsa.sign(
+///   key: private_key,
+///   message: <<"hello":utf8>>,
+///   hash: crypto.Sha256,
+/// )
+/// ```
+///
+@external(erlang, "gleam_crypto_ecdsa_ffi", "sign")
+@external(javascript, "../../gleam_crypto_ecdsa_ffi.mjs", "sign")
+pub fn sign(
+  key key: PrivateKey,
+  message message: BitArray,
+  hash hash: HashAlgorithm,
+) -> BitArray
+
+/// Verify an ECDSA signature.
+///
+/// Returns `True` if the signature is valid, `False` otherwise.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let is_valid = ecdsa.verify(
+///   key: public_key,
+///   message: <<"hello":utf8>>,
+///   signature: signature,
+///   hash: crypto.Sha256,
+/// )
+/// ```
+///
+@external(erlang, "gleam_crypto_ecdsa_ffi", "verify")
+@external(javascript, "../../gleam_crypto_ecdsa_ffi.mjs", "verify")
+pub fn verify(
+  key key: PublicKey,
+  message message: BitArray,
+  signature signature: BitArray,
+  hash hash: HashAlgorithm,
+) -> Bool

--- a/src/gleam/crypto/rsa.gleam
+++ b/src/gleam/crypto/rsa.gleam
@@ -1,0 +1,144 @@
+//// RSA cryptographic operations for signing and verification.
+
+import gleam/crypto.{type HashAlgorithm, type KeyFormat}
+
+/// RSA private key for signing operations.
+pub type PrivateKey
+
+/// RSA public key for verification operations.
+pub type PublicKey
+
+/// RSA signature padding schemes.
+pub type Padding {
+  /// PKCS#1 v1.5 padding. Widely supported, deterministic signatures.
+  Pkcs1v15
+  /// Probabilistic Signature Scheme. Modern, randomized.
+  Pss
+}
+
+/// RSA private key export format.
+pub type PrivateKeyFormat {
+  /// PKCS#1 RSAPrivateKey format (legacy).
+  Pkcs1
+  /// PKCS#8 PrivateKeyInfo format (preferred, standard).
+  Pkcs8
+}
+
+/// Generate a new RSA key pair with the specified bit size.
+///
+/// Common sizes are 2048, 3072, or 4096 bits.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let assert Ok(#(private_key, public_key)) = rsa.generate_key_pair(bits: 2048)
+/// ```
+///
+@external(erlang, "gleam_crypto_rsa_ffi", "generate_key_pair")
+@external(javascript, "../../gleam_crypto_rsa_ffi.mjs", "generateKeyPair")
+pub fn generate_key_pair(
+  bits bits: Int,
+) -> Result(#(PrivateKey, PublicKey), Nil)
+
+/// Import an RSA private key from PEM or DER encoded data.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let assert Ok(key) = rsa.private_key(pem_data, format: crypto.Pem)
+/// ```
+///
+@external(erlang, "gleam_crypto_rsa_ffi", "private_key")
+@external(javascript, "../../gleam_crypto_rsa_ffi.mjs", "privateKey")
+pub fn private_key(
+  data: BitArray,
+  format format: KeyFormat,
+) -> Result(PrivateKey, Nil)
+
+/// Import an RSA public key from PEM or DER encoded data.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let assert Ok(key) = rsa.public_key(pem_data, format: crypto.Pem)
+/// ```
+///
+@external(erlang, "gleam_crypto_rsa_ffi", "public_key")
+@external(javascript, "../../gleam_crypto_rsa_ffi.mjs", "publicKey")
+pub fn public_key(
+  data: BitArray,
+  format format: KeyFormat,
+) -> Result(PublicKey, Nil)
+
+/// Export an RSA private key to PEM or DER format.
+///
+@external(erlang, "gleam_crypto_rsa_ffi", "private_key_to_bytes")
+@external(javascript, "../../gleam_crypto_rsa_ffi.mjs", "privateKeyToBytes")
+pub fn private_key_to_bytes(
+  key key: PrivateKey,
+  format format: KeyFormat,
+  key_format key_format: PrivateKeyFormat,
+) -> BitArray
+
+/// Export an RSA public key to PEM or DER format.
+///
+@external(erlang, "gleam_crypto_rsa_ffi", "public_key_to_bytes")
+@external(javascript, "../../gleam_crypto_rsa_ffi.mjs", "publicKeyToBytes")
+pub fn public_key_to_bytes(
+  key key: PublicKey,
+  format format: KeyFormat,
+) -> BitArray
+
+/// Extract the public key from an RSA private key.
+///
+@external(erlang, "gleam_crypto_rsa_ffi", "public_key_from_private")
+@external(javascript, "../../gleam_crypto_rsa_ffi.mjs", "publicKeyFromPrivate")
+pub fn public_key_from_private(key key: PrivateKey) -> PublicKey
+
+/// Sign a message using an RSA private key.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let signature = rsa.sign(
+///   key: private_key,
+///   message: <<"hello":utf8>>,
+///   hash: crypto.Sha256,
+///   padding: rsa.Pss,
+/// )
+/// ```
+///
+@external(erlang, "gleam_crypto_rsa_ffi", "sign")
+@external(javascript, "../../gleam_crypto_rsa_ffi.mjs", "sign")
+pub fn sign(
+  key key: PrivateKey,
+  message message: BitArray,
+  hash hash: HashAlgorithm,
+  padding padding: Padding,
+) -> BitArray
+
+/// Verify an RSA signature.
+///
+/// Returns `True` if the signature is valid, `False` otherwise.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let is_valid = rsa.verify(
+///   key: public_key,
+///   message: <<"hello":utf8>>,
+///   signature: signature,
+///   hash: crypto.Sha256,
+///   padding: rsa.Pss,
+/// )
+/// ```
+///
+@external(erlang, "gleam_crypto_rsa_ffi", "verify")
+@external(javascript, "../../gleam_crypto_rsa_ffi.mjs", "verify")
+pub fn verify(
+  key key: PublicKey,
+  message message: BitArray,
+  signature signature: BitArray,
+  hash hash: HashAlgorithm,
+  padding padding: Padding,
+) -> Bool

--- a/src/gleam_crypto_ecdsa_ffi.erl
+++ b/src/gleam_crypto_ecdsa_ffi.erl
@@ -1,0 +1,190 @@
+-module(gleam_crypto_ecdsa_ffi).
+
+-include_lib("public_key/include/public_key.hrl").
+
+-export([generate_key_pair/1, private_key/2, public_key/2, private_key_to_bytes/2,
+         public_key_to_bytes/2, public_key_from_private/1, sign/3, verify/4]).
+
+convert_algorithm(sha1) ->
+    sha;
+convert_algorithm(Algorithm) ->
+    Algorithm.
+
+curve_name(p256) ->
+    secp256r1;
+curve_name(p384) ->
+    secp384r1;
+curve_name(p521) ->
+    secp521r1.
+
+oid_to_curve(?secp256r1) ->
+    secp256r1;
+oid_to_curve(?secp384r1) ->
+    secp384r1;
+oid_to_curve(?secp521r1) ->
+    secp521r1.
+
+curve_to_oid(secp256r1) ->
+    ?secp256r1;
+curve_to_oid(secp384r1) ->
+    ?secp384r1;
+curve_to_oid(secp521r1) ->
+    ?secp521r1.
+
+%% --- Key Generation ---
+
+generate_key_pair(Curve) ->
+    try
+        CurveName = curve_name(Curve),
+        {PubPoint, PrivKey} = crypto:generate_key(ecdh, CurveName),
+        {ok, {{ecdsa_private, PrivKey, PubPoint, CurveName}, {ecdsa_public, PubPoint, CurveName}}}
+    catch
+        _:_ ->
+            {error, nil}
+    end.
+
+%% --- Key Import ---
+
+private_key(Data, Format) ->
+    try
+        case Format of
+            pem ->
+                [Entry | _] = public_key:pem_decode(Data),
+                Key = public_key:pem_entry_decode(Entry),
+                private_key_from_record(Key);
+            der ->
+                Key = public_key:der_decode('ECPrivateKey', Data),
+                private_key_from_record(Key)
+        end
+    catch
+        _:_ ->
+            {error, nil}
+    end.
+
+private_key_from_record(#'ECPrivateKey'{privateKey = PrivKey,
+                                        parameters = {namedCurve, OID},
+                                        publicKey = PubKey}) ->
+    PrivKeyBin =
+        case is_list(PrivKey) of
+            true ->
+                list_to_binary(PrivKey);
+            false ->
+                PrivKey
+        end,
+    CurveName = oid_to_curve(OID),
+    PubPoint =
+        case PubKey of
+            undefined ->
+                {DerivedPub, _} = crypto:generate_key(ecdh, CurveName, PrivKeyBin),
+                DerivedPub;
+            asn1_NOVALUE ->
+                {DerivedPub, _} = crypto:generate_key(ecdh, CurveName, PrivKeyBin),
+                DerivedPub;
+            _ ->
+                PubKey
+        end,
+    {ok, {ecdsa_private, PrivKeyBin, PubPoint, CurveName}};
+private_key_from_record(#'PrivateKeyInfo'{privateKeyAlgorithm =
+                                              #'PrivateKeyInfo_privateKeyAlgorithm'{algorithm =
+                                                                                        ?'id-ecPublicKey',
+                                                                                    parameters =
+                                                                                        Params},
+                                          privateKey = PrivKeyDer}) ->
+    {asn1_OPENTYPE, ParamsDer} = Params,
+    {ok, OID} = 'OTP-PUB-KEY':decode('EcpkParameters', ParamsDer),
+    Key = public_key:der_decode('ECPrivateKey', PrivKeyDer),
+    private_key_from_record(Key#'ECPrivateKey'{parameters = {namedCurve, OID}});
+private_key_from_record(_) ->
+    {error, nil}.
+
+public_key(Data, Format) ->
+    try
+        case Format of
+            pem ->
+                [Entry | _] = public_key:pem_decode(Data),
+                Key = public_key:pem_entry_decode(Entry),
+                public_key_from_record(Key);
+            der ->
+                Key = public_key:der_decode('SubjectPublicKeyInfo', Data),
+                public_key_from_record(Key)
+        end
+    catch
+        _:_ ->
+            {error, nil}
+    end.
+
+public_key_from_record(#'SubjectPublicKeyInfo'{algorithm =
+                                                   #'AlgorithmIdentifier'{algorithm =
+                                                                              ?'id-ecPublicKey',
+                                                                          parameters = Params},
+                                               subjectPublicKey = PubKey}) ->
+    %% Parameters can be DER-encoded bytes or already decoded {namedCurve, OID}
+    {namedCurve, OID} =
+        case Params of
+            {namedCurve, _} ->
+                Params;
+            _ ->
+                public_key:der_decode('EcpkParameters', Params)
+        end,
+    CurveName = oid_to_curve(OID),
+    {ok, {ecdsa_public, PubKey, CurveName}};
+%% Format returned by public_key:pem_entry_decode for EC public keys
+public_key_from_record({{'ECPoint', PubKey}, {namedCurve, OID}}) ->
+    CurveName = oid_to_curve(OID),
+    {ok, {ecdsa_public, PubKey, CurveName}};
+public_key_from_record({{#'ECPoint'{point = PubKey}, {namedCurve, OID}}, _}) ->
+    CurveName = oid_to_curve(OID),
+    {ok, {ecdsa_public, PubKey, CurveName}};
+public_key_from_record(_) ->
+    {error, nil}.
+
+%% --- Key Export ---
+
+private_key_to_bytes({ecdsa_private, PrivKey, PubKey, CurveName}, Format) ->
+    OID = curve_to_oid(CurveName),
+    Record =
+        #'ECPrivateKey'{version = 1,
+                        privateKey = binary_to_list(PrivKey),
+                        parameters = {namedCurve, OID},
+                        publicKey = PubKey},
+    case Format of
+        pem ->
+            PemEntry = public_key:pem_entry_encode('ECPrivateKey', Record),
+            public_key:pem_encode([PemEntry]);
+        der ->
+            public_key:der_encode('ECPrivateKey', Record)
+    end.
+
+public_key_to_bytes({ecdsa_public, PubKey, CurveName}, Format) ->
+    OID = curve_to_oid(CurveName),
+    Record =
+        #'SubjectPublicKeyInfo'{algorithm =
+                                    #'AlgorithmIdentifier'{algorithm = ?'id-ecPublicKey',
+                                                           parameters = {namedCurve, OID}},
+                                subjectPublicKey = PubKey},
+    case Format of
+        pem ->
+            PemEntry = public_key:pem_entry_encode('SubjectPublicKeyInfo', Record),
+            public_key:pem_encode([PemEntry]);
+        der ->
+            public_key:der_encode('SubjectPublicKeyInfo', Record)
+    end.
+
+%% --- Public Key Derivation ---
+
+public_key_from_private({ecdsa_private, _PrivKey, PubKey, CurveName}) ->
+    {ecdsa_public, PubKey, CurveName}.
+
+%% --- Sign/Verify ---
+
+sign({ecdsa_private, PrivKey, _PubKey, CurveName}, Message, Hash) ->
+    Algorithm = convert_algorithm(Hash),
+    crypto:sign(ecdsa, Algorithm, Message, [PrivKey, CurveName]).
+
+verify({ecdsa_public, PubKey, CurveName}, Message, Signature, Hash) ->
+    Algorithm = convert_algorithm(Hash),
+    try
+        crypto:verify(ecdsa, Algorithm, Message, Signature, [PubKey, CurveName])
+    catch
+        _:_ -> false
+    end.

--- a/src/gleam_crypto_ecdsa_ffi.mjs
+++ b/src/gleam_crypto_ecdsa_ffi.mjs
@@ -1,0 +1,158 @@
+import { BitArray, Ok, Error as ResultError } from "./gleam.mjs";
+import {
+  Sha1,
+  Sha224,
+  Sha256,
+  Sha384,
+  Sha512,
+  Md5,
+  Pem,
+  Der,
+} from "./gleam/crypto.mjs";
+import { P256, P384, P521 } from "./gleam/crypto/ecdsa.mjs";
+import * as crypto from "node:crypto";
+
+function algorithmName(algorithm) {
+  if (algorithm instanceof Sha1) {
+    return "sha1";
+  } else if (algorithm instanceof Sha224) {
+    return "sha224";
+  } else if (algorithm instanceof Sha256) {
+    return "sha256";
+  } else if (algorithm instanceof Sha384) {
+    return "sha384";
+  } else if (algorithm instanceof Sha512) {
+    return "sha512";
+  } else if (algorithm instanceof Md5) {
+    return "md5";
+  } else {
+    throw new Error("Unsupported algorithm");
+  }
+}
+
+function formatName(format) {
+  if (format instanceof Pem) {
+    return "pem";
+  } else if (format instanceof Der) {
+    return "der";
+  } else {
+    throw new Error("Unsupported format");
+  }
+}
+
+function curveName(curve) {
+  if (curve instanceof P256) {
+    return "prime256v1";
+  } else if (curve instanceof P384) {
+    return "secp384r1";
+  } else if (curve instanceof P521) {
+    return "secp521r1";
+  } else {
+    throw new Error("Unsupported curve");
+  }
+}
+
+// --- Key Generation ---
+
+export function generateKeyPair(curve) {
+  try {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", {
+      namedCurve: curveName(curve),
+    });
+    return new Ok([privateKey, publicKey]);
+  } catch (e) {
+    return new ResultError(undefined);
+  }
+}
+
+// --- Key Import ---
+
+export function privateKey(data, format) {
+  try {
+    const fmt = formatName(format);
+    const key = crypto.createPrivateKey({
+      key: data.rawBuffer,
+      format: fmt,
+      type: fmt === "pem" ? undefined : "sec1",
+    });
+    return new Ok(key);
+  } catch (e) {
+    // Try PKCS8 format for DER
+    if (format instanceof Der) {
+      try {
+        const key = crypto.createPrivateKey({
+          key: data.rawBuffer,
+          format: "der",
+          type: "pkcs8",
+        });
+        return new Ok(key);
+      } catch (e2) {
+        return new ResultError(undefined);
+      }
+    }
+    return new ResultError(undefined);
+  }
+}
+
+export function publicKey(data, format) {
+  try {
+    const fmt = formatName(format);
+    const key = crypto.createPublicKey({
+      key: data.rawBuffer,
+      format: fmt,
+      type: fmt === "pem" ? undefined : "spki",
+    });
+    return new Ok(key);
+  } catch (e) {
+    return new ResultError(undefined);
+  }
+}
+
+// --- Key Export ---
+
+export function privateKeyToBytes(key, format) {
+  const fmt = formatName(format);
+  const exported = key.export({
+    format: fmt,
+    type: "sec1",
+  });
+  if (fmt === "pem") {
+    return new BitArray(new Uint8Array(Buffer.from(exported)));
+  }
+  return new BitArray(new Uint8Array(exported));
+}
+
+export function publicKeyToBytes(key, format) {
+  const fmt = formatName(format);
+  const exported = key.export({
+    format: fmt,
+    type: "spki",
+  });
+  if (fmt === "pem") {
+    return new BitArray(new Uint8Array(Buffer.from(exported)));
+  }
+  return new BitArray(new Uint8Array(exported));
+}
+
+// --- Public Key Derivation ---
+
+export function publicKeyFromPrivate(privateKey) {
+  return crypto.createPublicKey(privateKey);
+}
+
+// --- Sign/Verify ---
+
+export function sign(key, message, hash) {
+  const algo = algorithmName(hash);
+  const signature = crypto.sign(algo, message.rawBuffer, key);
+  return new BitArray(new Uint8Array(signature));
+}
+
+export function verify(key, message, signature, hash) {
+  const algo = algorithmName(hash);
+  try {
+    return crypto.verify(algo, message.rawBuffer, key, signature.rawBuffer);
+  } catch (e) {
+    return false;
+  }
+}

--- a/src/gleam_crypto_rsa_ffi.erl
+++ b/src/gleam_crypto_rsa_ffi.erl
@@ -1,0 +1,169 @@
+-module(gleam_crypto_rsa_ffi).
+
+-include_lib("public_key/include/public_key.hrl").
+
+-export([generate_key_pair/1, private_key/2, public_key/2, private_key_to_bytes/3,
+         public_key_to_bytes/2, public_key_from_private/1, sign/4, verify/5]).
+
+%% Standard RSA public exponent
+-define(RSA_PUBLIC_EXPONENT, 65537).
+
+convert_algorithm(sha1) ->
+    sha;
+convert_algorithm(Algorithm) ->
+    Algorithm.
+
+%% --- Key Generation ---
+
+generate_key_pair(Bits) ->
+    try
+        {[E, N], [E, N, D, P1, P2, E1, E2, C]} =
+            crypto:generate_key(rsa, {Bits, ?RSA_PUBLIC_EXPONENT}),
+        PrivateKey =
+            #'RSAPrivateKey'{version = 0,
+                             modulus = binary:decode_unsigned(N),
+                             publicExponent = binary:decode_unsigned(E),
+                             privateExponent = binary:decode_unsigned(D),
+                             prime1 = binary:decode_unsigned(P1),
+                             prime2 = binary:decode_unsigned(P2),
+                             exponent1 = binary:decode_unsigned(E1),
+                             exponent2 = binary:decode_unsigned(E2),
+                             coefficient = binary:decode_unsigned(C)},
+        PublicKey =
+            #'RSAPublicKey'{modulus = binary:decode_unsigned(N),
+                            publicExponent = binary:decode_unsigned(E)},
+        {ok, {{rsa_private, PrivateKey, PublicKey}, {rsa_public, PublicKey}}}
+    catch
+        _:_ ->
+            {error, nil}
+    end.
+
+%% --- Key Import ---
+
+private_key(Data, Format) ->
+    try
+        case Format of
+            pem ->
+                [Entry | _] = public_key:pem_decode(Data),
+                Key = public_key:pem_entry_decode(Entry),
+                private_key_from_record(Key);
+            der ->
+                try
+                    Key = public_key:der_decode('RSAPrivateKey', Data),
+                    private_key_from_record(Key)
+                catch
+                    _:_ ->
+                        Key2 = public_key:der_decode('PrivateKeyInfo', Data),
+                        private_key_from_record(Key2)
+                end
+        end
+    catch
+        _:_ ->
+            {error, nil}
+    end.
+
+private_key_from_record(#'RSAPrivateKey'{modulus = N, publicExponent = E} = Key) ->
+    PublicKey = #'RSAPublicKey'{modulus = N, publicExponent = E},
+    {ok, {rsa_private, Key, PublicKey}};
+private_key_from_record(#'PrivateKeyInfo'{privateKeyAlgorithm =
+                                              #'PrivateKeyInfo_privateKeyAlgorithm'{algorithm =
+                                                                                        ?rsaEncryption},
+                                          privateKey = PrivKeyDer}) ->
+    Key = public_key:der_decode('RSAPrivateKey', PrivKeyDer),
+    private_key_from_record(Key);
+private_key_from_record(_) ->
+    {error, nil}.
+
+public_key(Data, Format) ->
+    try
+        case Format of
+            pem ->
+                [Entry | _] = public_key:pem_decode(Data),
+                Key = public_key:pem_entry_decode(Entry),
+                public_key_from_record(Key);
+            der ->
+                try
+                    Key1 = public_key:der_decode('RSAPublicKey', Data),
+                    public_key_from_record(Key1)
+                catch
+                    _:_ ->
+                        Key2 = public_key:der_decode('SubjectPublicKeyInfo', Data),
+                        public_key_from_record(Key2)
+                end
+        end
+    catch
+        _:_ ->
+            {error, nil}
+    end.
+
+public_key_from_record(#'RSAPublicKey'{} = Key) ->
+    {ok, {rsa_public, Key}};
+public_key_from_record(#'SubjectPublicKeyInfo'{algorithm =
+                                                   #'AlgorithmIdentifier'{algorithm =
+                                                                              ?rsaEncryption},
+                                               subjectPublicKey = PubKeyDer}) ->
+    Key = public_key:der_decode('RSAPublicKey', PubKeyDer),
+    public_key_from_record(Key);
+public_key_from_record({#'RSAPublicKey'{} = Key, _Params}) ->
+    {ok, {rsa_public, Key}};
+public_key_from_record(_) ->
+    {error, nil}.
+
+%% --- Key Export ---
+
+private_key_to_bytes({rsa_private, Key, _PublicKey}, pem, pkcs1) ->
+    PemEntry = public_key:pem_entry_encode('RSAPrivateKey', Key),
+    public_key:pem_encode([PemEntry]);
+private_key_to_bytes({rsa_private, Key, _PublicKey}, der, pkcs1) ->
+    public_key:der_encode('RSAPrivateKey', Key);
+private_key_to_bytes({rsa_private, Key, _PublicKey}, pem, pkcs8) ->
+    PemEntry = public_key:pem_entry_encode('PrivateKeyInfo', privatekey_to_pkcs8(Key)),
+    public_key:pem_encode([PemEntry]);
+private_key_to_bytes({rsa_private, Key, _PublicKey}, der, pkcs8) ->
+    public_key:der_encode('PrivateKeyInfo', privatekey_to_pkcs8(Key)).
+
+privatekey_to_pkcs8(#'RSAPrivateKey'{} = Key) ->
+    Der = public_key:der_encode('RSAPrivateKey', Key),
+    #'PrivateKeyInfo'{
+        version = v1,
+        privateKeyAlgorithm = #'PrivateKeyInfo_privateKeyAlgorithm'{
+            algorithm = ?rsaEncryption,
+            parameters = {asn1_OPENTYPE, <<5, 0>>}
+        },
+        privateKey = Der
+    }.
+
+public_key_to_bytes({rsa_public, Key}, Format) ->
+    case Format of
+        pem ->
+            PemEntry = public_key:pem_entry_encode('RSAPublicKey', Key),
+            public_key:pem_encode([PemEntry]);
+        der ->
+            public_key:der_encode('RSAPublicKey', Key)
+    end.
+
+%% --- Public Key Derivation ---
+
+public_key_from_private({rsa_private, _PrivateKey, PublicKey}) ->
+    {rsa_public, PublicKey}.
+
+%% --- Sign/Verify ---
+
+sign({rsa_private, PrivateKey, _PublicKey}, Message, Hash, Padding) ->
+    Algorithm = convert_algorithm(Hash),
+    Options = padding_options(Padding, Algorithm),
+    public_key:sign(Message, Algorithm, PrivateKey, Options).
+
+verify({rsa_public, PublicKey}, Message, Signature, Hash, Padding) ->
+    Algorithm = convert_algorithm(Hash),
+    Options = padding_options(Padding, Algorithm),
+    try
+        public_key:verify(Message, Algorithm, Signature, PublicKey, Options)
+    catch
+        _:_ -> false
+    end.
+
+padding_options(pkcs1v15, _Algorithm) ->
+    [{rsa_padding, rsa_pkcs1_padding}];
+padding_options(pss, Algorithm) ->
+    [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, -1}, {rsa_mgf1_md, Algorithm}].

--- a/src/gleam_crypto_rsa_ffi.mjs
+++ b/src/gleam_crypto_rsa_ffi.mjs
@@ -1,0 +1,191 @@
+import { BitArray, Ok, Error as ResultError } from "./gleam.mjs";
+import {
+  Sha1,
+  Sha224,
+  Sha256,
+  Sha384,
+  Sha512,
+  Md5,
+  Pem,
+  Der,
+} from "./gleam/crypto.mjs";
+import { Pkcs1v15, Pss, Pkcs1, Pkcs8 } from "./gleam/crypto/rsa.mjs";
+import * as crypto from "node:crypto";
+
+// Standard RSA public exponent
+const RSA_PUBLIC_EXPONENT = 65537;
+
+function algorithmName(algorithm) {
+  if (algorithm instanceof Sha1) {
+    return "sha1";
+  } else if (algorithm instanceof Sha224) {
+    return "sha224";
+  } else if (algorithm instanceof Sha256) {
+    return "sha256";
+  } else if (algorithm instanceof Sha384) {
+    return "sha384";
+  } else if (algorithm instanceof Sha512) {
+    return "sha512";
+  } else if (algorithm instanceof Md5) {
+    return "md5";
+  } else {
+    throw new Error("Unsupported algorithm");
+  }
+}
+
+function formatName(format) {
+  if (format instanceof Pem) {
+    return "pem";
+  } else if (format instanceof Der) {
+    return "der";
+  } else {
+    throw new Error("Unsupported format");
+  }
+}
+
+// --- Key Generation ---
+
+export function generateKeyPair(bits) {
+  try {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: bits,
+      publicExponent: RSA_PUBLIC_EXPONENT,
+    });
+    return new Ok([privateKey, publicKey]);
+  } catch (e) {
+    return new ResultError(undefined);
+  }
+}
+
+// --- Key Import ---
+
+export function privateKey(data, format) {
+  try {
+    const fmt = formatName(format);
+    const key = crypto.createPrivateKey({
+      key: data.rawBuffer,
+      format: fmt,
+      type: fmt === "pem" ? undefined : "pkcs1",
+    });
+    return new Ok(key);
+  } catch (e) {
+    // Try PKCS8 format for DER
+    if (format instanceof Der) {
+      try {
+        const key = crypto.createPrivateKey({
+          key: data.rawBuffer,
+          format: "der",
+          type: "pkcs8",
+        });
+        return new Ok(key);
+      } catch (e2) {
+        return new ResultError(undefined);
+      }
+    }
+    return new ResultError(undefined);
+  }
+}
+
+export function publicKey(data, format) {
+  try {
+    const fmt = formatName(format);
+    const key = crypto.createPublicKey({
+      key: data.rawBuffer,
+      format: fmt,
+      type: fmt === "pem" ? undefined : "pkcs1",
+    });
+    return new Ok(key);
+  } catch (e) {
+    if (format instanceof Der) {
+      try {
+        const key = crypto.createPublicKey({
+          key: data.rawBuffer,
+          format: "der",
+          type: "spki",
+        });
+        return new Ok(key);
+      } catch (e2) {
+        return new ResultError(undefined);
+      }
+    }
+    return new ResultError(undefined);
+  }
+}
+
+// --- Key Export ---
+
+export function privateKeyToBytes(key, format, keyFormat) {
+  const fmt = formatName(format);
+  const type = keyFormat instanceof Pkcs1 ? "pkcs1" : "pkcs8";
+  const exported = key.export({
+    format: fmt,
+    type: type,
+  });
+  if (fmt === "pem") {
+    return new BitArray(new Uint8Array(Buffer.from(exported)));
+  }
+  return new BitArray(new Uint8Array(exported));
+}
+
+export function publicKeyToBytes(key, format) {
+  const fmt = formatName(format);
+  const exported = key.export({
+    format: fmt,
+    type: "pkcs1",
+  });
+  if (fmt === "pem") {
+    return new BitArray(new Uint8Array(Buffer.from(exported)));
+  }
+  return new BitArray(new Uint8Array(exported));
+}
+
+// --- Public Key Derivation ---
+
+export function publicKeyFromPrivate(privateKey) {
+  return crypto.createPublicKey(privateKey);
+}
+
+// --- Sign/Verify ---
+
+export function sign(key, message, hash, padding) {
+  const algo = algorithmName(hash);
+  const paddingValue =
+    padding instanceof Pss
+      ? crypto.constants.RSA_PKCS1_PSS_PADDING
+      : crypto.constants.RSA_PKCS1_PADDING;
+
+  const options = {
+    key: key,
+    padding: paddingValue,
+  };
+
+  if (padding instanceof Pss) {
+    options.saltLength = crypto.constants.RSA_PSS_SALTLEN_DIGEST;
+  }
+
+  const signature = crypto.sign(algo, message.rawBuffer, options);
+  return new BitArray(new Uint8Array(signature));
+}
+
+export function verify(key, message, signature, hash, padding) {
+  const algo = algorithmName(hash);
+  const paddingValue =
+    padding instanceof Pss
+      ? crypto.constants.RSA_PKCS1_PSS_PADDING
+      : crypto.constants.RSA_PKCS1_PADDING;
+
+  const options = {
+    key: key,
+    padding: paddingValue,
+  };
+
+  if (padding instanceof Pss) {
+    options.saltLength = crypto.constants.RSA_PSS_SALTLEN_DIGEST;
+  }
+
+  try {
+    return crypto.verify(algo, message.rawBuffer, options, signature.rawBuffer);
+  } catch (e) {
+    return false;
+  }
+}

--- a/test/gleam/crypto/ecdsa_test.gleam
+++ b/test/gleam/crypto/ecdsa_test.gleam
@@ -1,0 +1,154 @@
+import gleam/crypto
+import gleam/crypto/ecdsa
+import gleeunit/should
+
+pub fn generate_key_pair_p256_test() {
+  let assert Ok(#(private_key, public_key)) =
+    ecdsa.generate_key_pair(curve: ecdsa.P256)
+
+  let message = <<"Hello, ECDSA P256!":utf8>>
+  let signature =
+    ecdsa.sign(key: private_key, message: message, hash: crypto.Sha256)
+
+  ecdsa.verify(
+    key: public_key,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+  )
+  |> should.equal(True)
+}
+
+pub fn generate_key_pair_p384_test() {
+  let assert Ok(#(private_key, public_key)) =
+    ecdsa.generate_key_pair(curve: ecdsa.P384)
+
+  let message = <<"Hello, ECDSA P384!":utf8>>
+  let signature =
+    ecdsa.sign(key: private_key, message: message, hash: crypto.Sha384)
+
+  ecdsa.verify(
+    key: public_key,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha384,
+  )
+  |> should.equal(True)
+}
+
+pub fn generate_key_pair_p521_test() {
+  let assert Ok(#(private_key, public_key)) =
+    ecdsa.generate_key_pair(curve: ecdsa.P521)
+
+  let message = <<"Hello, ECDSA P521!":utf8>>
+  let signature =
+    ecdsa.sign(key: private_key, message: message, hash: crypto.Sha512)
+
+  ecdsa.verify(
+    key: public_key,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha512,
+  )
+  |> should.equal(True)
+}
+
+pub fn verify_wrong_message_test() {
+  let assert Ok(#(private_key, public_key)) =
+    ecdsa.generate_key_pair(curve: ecdsa.P256)
+
+  let message = <<"Original message":utf8>>
+  let signature =
+    ecdsa.sign(key: private_key, message: message, hash: crypto.Sha256)
+
+  ecdsa.verify(
+    key: public_key,
+    message: <<"Different message":utf8>>,
+    signature: signature,
+    hash: crypto.Sha256,
+  )
+  |> should.equal(False)
+}
+
+pub fn public_key_from_private_test() {
+  let assert Ok(#(private_key, public_key)) =
+    ecdsa.generate_key_pair(curve: ecdsa.P256)
+
+  let derived_public_key = ecdsa.public_key_from_private(key: private_key)
+
+  let message = <<"Derived ECDSA key test":utf8>>
+  let signature =
+    ecdsa.sign(key: private_key, message: message, hash: crypto.Sha256)
+
+  ecdsa.verify(
+    key: derived_public_key,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+  )
+  |> should.equal(True)
+
+  ecdsa.verify(
+    key: public_key,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+  )
+  |> should.equal(True)
+}
+
+pub fn key_export_import_pem_test() {
+  let assert Ok(#(private_key, _public_key)) =
+    ecdsa.generate_key_pair(curve: ecdsa.P256)
+
+  let private_pem =
+    ecdsa.private_key_to_bytes(key: private_key, format: crypto.Pem)
+  let public_key = ecdsa.public_key_from_private(key: private_key)
+  let public_pem =
+    ecdsa.public_key_to_bytes(key: public_key, format: crypto.Pem)
+
+  let assert Ok(imported_private) =
+    ecdsa.private_key(private_pem, format: crypto.Pem)
+  let assert Ok(imported_public) =
+    ecdsa.public_key(public_pem, format: crypto.Pem)
+
+  let message = <<"ECDSA PEM import/export test":utf8>>
+  let signature =
+    ecdsa.sign(key: imported_private, message: message, hash: crypto.Sha256)
+
+  ecdsa.verify(
+    key: imported_public,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+  )
+  |> should.equal(True)
+}
+
+pub fn key_export_import_der_test() {
+  let assert Ok(#(private_key, _public_key)) =
+    ecdsa.generate_key_pair(curve: ecdsa.P256)
+
+  let private_der =
+    ecdsa.private_key_to_bytes(key: private_key, format: crypto.Der)
+  let public_key = ecdsa.public_key_from_private(key: private_key)
+  let public_der =
+    ecdsa.public_key_to_bytes(key: public_key, format: crypto.Der)
+
+  let assert Ok(imported_private) =
+    ecdsa.private_key(private_der, format: crypto.Der)
+  let assert Ok(imported_public) =
+    ecdsa.public_key(public_der, format: crypto.Der)
+
+  let message = <<"ECDSA DER import/export test":utf8>>
+  let signature =
+    ecdsa.sign(key: imported_private, message: message, hash: crypto.Sha256)
+
+  ecdsa.verify(
+    key: imported_public,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+  )
+  |> should.equal(True)
+}

--- a/test/gleam/crypto/rsa_test.gleam
+++ b/test/gleam/crypto/rsa_test.gleam
@@ -1,0 +1,255 @@
+import gleam/crypto
+import gleam/crypto/rsa
+import gleeunit/should
+
+pub fn generate_key_pair_2048_test() {
+  let assert Ok(#(private_key, public_key)) = rsa.generate_key_pair(bits: 2048)
+
+  let message = <<"Too many secrets":utf8>>
+  let signature =
+    rsa.sign(
+      key: private_key,
+      message: message,
+      hash: crypto.Sha256,
+      padding: rsa.Pss,
+    )
+
+  rsa.verify(
+    key: public_key,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+    padding: rsa.Pss,
+  )
+  |> should.equal(True)
+}
+
+pub fn sign_verify_pss_sha256_test() {
+  let assert Ok(#(private_key, public_key)) = rsa.generate_key_pair(bits: 2048)
+
+  let message = <<"Test message for RSA-PSS":utf8>>
+  let signature =
+    rsa.sign(
+      key: private_key,
+      message: message,
+      hash: crypto.Sha256,
+      padding: rsa.Pss,
+    )
+
+  rsa.verify(
+    key: public_key,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+    padding: rsa.Pss,
+  )
+  |> should.equal(True)
+
+  rsa.verify(
+    key: public_key,
+    message: <<"Wrong message":utf8>>,
+    signature: signature,
+    hash: crypto.Sha256,
+    padding: rsa.Pss,
+  )
+  |> should.equal(False)
+}
+
+pub fn sign_verify_pkcs1v15_sha256_test() {
+  let assert Ok(#(private_key, public_key)) = rsa.generate_key_pair(bits: 2048)
+
+  let message = <<"Test message for RSA-PKCS1v15":utf8>>
+  let signature =
+    rsa.sign(
+      key: private_key,
+      message: message,
+      hash: crypto.Sha256,
+      padding: rsa.Pkcs1v15,
+    )
+
+  rsa.verify(
+    key: public_key,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+    padding: rsa.Pkcs1v15,
+  )
+  |> should.equal(True)
+}
+
+pub fn public_key_from_private_test() {
+  let assert Ok(#(private_key, public_key)) = rsa.generate_key_pair(bits: 2048)
+
+  let derived_public_key = rsa.public_key_from_private(key: private_key)
+
+  let message = <<"Derived key test":utf8>>
+  let signature =
+    rsa.sign(
+      key: private_key,
+      message: message,
+      hash: crypto.Sha256,
+      padding: rsa.Pss,
+    )
+
+  rsa.verify(
+    key: derived_public_key,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+    padding: rsa.Pss,
+  )
+  |> should.equal(True)
+
+  rsa.verify(
+    key: public_key,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+    padding: rsa.Pss,
+  )
+  |> should.equal(True)
+}
+
+pub fn key_export_import_pem_pkcs1_test() {
+  let assert Ok(#(private_key, _public_key)) = rsa.generate_key_pair(bits: 2048)
+
+  let private_pem =
+    rsa.private_key_to_bytes(
+      key: private_key,
+      format: crypto.Pem,
+      key_format: rsa.Pkcs1,
+    )
+  let public_key = rsa.public_key_from_private(key: private_key)
+  let public_pem = rsa.public_key_to_bytes(key: public_key, format: crypto.Pem)
+
+  let assert Ok(imported_private) =
+    rsa.private_key(private_pem, format: crypto.Pem)
+  let assert Ok(imported_public) =
+    rsa.public_key(public_pem, format: crypto.Pem)
+
+  let message = <<"Import/export test":utf8>>
+  let signature =
+    rsa.sign(
+      key: imported_private,
+      message: message,
+      hash: crypto.Sha256,
+      padding: rsa.Pss,
+    )
+
+  rsa.verify(
+    key: imported_public,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+    padding: rsa.Pss,
+  )
+  |> should.equal(True)
+}
+
+pub fn key_export_import_pem_pkcs8_test() {
+  let assert Ok(#(private_key, _public_key)) = rsa.generate_key_pair(bits: 2048)
+
+  let private_pem =
+    rsa.private_key_to_bytes(
+      key: private_key,
+      format: crypto.Pem,
+      key_format: rsa.Pkcs8,
+    )
+  let public_key = rsa.public_key_from_private(key: private_key)
+  let public_pem = rsa.public_key_to_bytes(key: public_key, format: crypto.Pem)
+
+  let assert Ok(imported_private) =
+    rsa.private_key(private_pem, format: crypto.Pem)
+  let assert Ok(imported_public) =
+    rsa.public_key(public_pem, format: crypto.Pem)
+
+  let message = <<"PKCS8 import/export test":utf8>>
+  let signature =
+    rsa.sign(
+      key: imported_private,
+      message: message,
+      hash: crypto.Sha256,
+      padding: rsa.Pss,
+    )
+
+  rsa.verify(
+    key: imported_public,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+    padding: rsa.Pss,
+  )
+  |> should.equal(True)
+}
+
+pub fn key_export_import_der_pkcs1_test() {
+  let assert Ok(#(private_key, _public_key)) = rsa.generate_key_pair(bits: 2048)
+
+  let private_der =
+    rsa.private_key_to_bytes(
+      key: private_key,
+      format: crypto.Der,
+      key_format: rsa.Pkcs1,
+    )
+  let public_key = rsa.public_key_from_private(key: private_key)
+  let public_der = rsa.public_key_to_bytes(key: public_key, format: crypto.Der)
+
+  let assert Ok(imported_private) =
+    rsa.private_key(private_der, format: crypto.Der)
+  let assert Ok(imported_public) =
+    rsa.public_key(public_der, format: crypto.Der)
+
+  let message = <<"DER import/export test":utf8>>
+  let signature =
+    rsa.sign(
+      key: imported_private,
+      message: message,
+      hash: crypto.Sha256,
+      padding: rsa.Pkcs1v15,
+    )
+
+  rsa.verify(
+    key: imported_public,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+    padding: rsa.Pkcs1v15,
+  )
+  |> should.equal(True)
+}
+
+pub fn key_export_import_der_pkcs8_test() {
+  let assert Ok(#(private_key, _public_key)) = rsa.generate_key_pair(bits: 2048)
+
+  let private_der =
+    rsa.private_key_to_bytes(
+      key: private_key,
+      format: crypto.Der,
+      key_format: rsa.Pkcs8,
+    )
+  let public_key = rsa.public_key_from_private(key: private_key)
+  let public_der = rsa.public_key_to_bytes(key: public_key, format: crypto.Der)
+
+  let assert Ok(imported_private) =
+    rsa.private_key(private_der, format: crypto.Der)
+  let assert Ok(imported_public) =
+    rsa.public_key(public_der, format: crypto.Der)
+
+  let message = <<"DER PKCS8 import/export test":utf8>>
+  let signature =
+    rsa.sign(
+      key: imported_private,
+      message: message,
+      hash: crypto.Sha256,
+      padding: rsa.Pkcs1v15,
+    )
+
+  rsa.verify(
+    key: imported_public,
+    message: message,
+    signature: signature,
+    hash: crypto.Sha256,
+    padding: rsa.Pkcs1v15,
+  )
+  |> should.equal(True)
+}


### PR DESCRIPTION
I am working on a Gleam library for WebAuthn/FIDO2 and needed ECDSA signing. So far, I've just been using FFI, but it made sense to upstream what I had been doing. I decided in this PR to put RSA and ECDSA into their own module because the function and type names were getting long in the main module. In some future version, it makes sense to rename the root module to hash or hashing since it deals with hash functions and HMAC.